### PR TITLE
Cap FluentAssertions to Open Licence

### DIFF
--- a/RecentFileCache.Test/RecentFileCache.Test.csproj
+++ b/RecentFileCache.Test/RecentFileCache.Test.csproj
@@ -13,7 +13,7 @@
     <None Include="Files\RecentFileCache.bcf" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="FluentAssertions" Version="[7.0.0,8.0.0)" />
     <PackageReference Include="NUnit" Version="4.3.2" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Due to the mess of [here](https://github.com/fluentassertions/fluentassertions/pull/2943). Protects against License Change 